### PR TITLE
Support jump tables in BSPL.

### DIFF
--- a/3/src/bspl/bspl.fs
+++ b/3/src/bspl/bspl.fs
@@ -19,6 +19,28 @@ S" bspl.fm/asm.fs" included
 \ fake a word which, when invoked, compiles a call to that routine.
 : extern	>in @ bl word count define swap >in ! create , does> @ call, ;
 
+\ Jump tables are important structures, permitting polymorphic
+\ program execution.  Note that these constructs exist outside
+\ of any colon definition; therefore, they emit raw assembly
+\ language immediately!
+
+  ( I'd like to find a better place to put this code. )
+  ( Unfortunately, I have a bit of a circular dependency if )
+  ( I place it where it logically should go. )
+
+: jtasm		."  align 8" cr 32 word count type ." :" cr
+		."  jal t0, __jumptable__" cr ;
+: jump-table,	>in @ jtasm >in ! extern ;
+: entry,	32 word count 2dup S" ;" compare if ."  jal x0, " type cr 1 else 0 then ;
+: jump-entries,	begin entry, 0= until ;
+
+target definitions
+
+:: jump-table:		jump-table, ;
+:: jump-entries:	jump-entries, ;
+
+host definitions
+
 \ The new colon compiler starts here.  It's technically part of
 \ pass 1 implementation, but ; drives subsequent passes as well.
 

--- a/3/src/stsv1/bspl-abi/bspl-regs.i
+++ b/3/src/stsv1/bspl-abi/bspl-regs.i
@@ -7,3 +7,4 @@ dsp     = x2    ; Data stack pointer.
 rsp     = x3    ; Return stack pointer.
 gvp     = x4    ; Global variables pointer.
 gp      = x5    ; Globals pointer.
+t0	= x6	; Temporary used by the compiler.

--- a/3/src/stsv1/bspl-abi/bspl-regs.i
+++ b/3/src/stsv1/bspl-abi/bspl-regs.i
@@ -5,5 +5,5 @@
 ra      = x1    ; Return address
 dsp     = x2    ; Data stack pointer.
 rsp     = x3    ; Return stack pointer.
-gvp     = x4    ; Global vector pointer.
+gvp     = x4    ; Global variables pointer.
 gp      = x5    ; Globals pointer.

--- a/3/src/stsv1/bspl-abi/bspl-regs.i
+++ b/3/src/stsv1/bspl-abi/bspl-regs.i
@@ -1,0 +1,9 @@
+; This Source Code Form is subject to the terms of the Mozilla Public
+; License, v. 2.0. If a copy of the MPL was not distributed with this
+; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+ra      = x1    ; Return address
+dsp     = x2    ; Data stack pointer.
+rsp     = x3    ; Return stack pointer.
+gvp     = x4    ; Global vector pointer.
+gp      = x5    ; Globals pointer.

--- a/3/src/stsv1/bspl-abi/bspl-suffix.asm
+++ b/3/src/stsv1/bspl-abi/bspl-suffix.asm
@@ -12,6 +12,26 @@ bye:            addi    rsp, rsp, -8
                 csrrw   x0, rsp, mtohost
                 jal     x0, *
 
+; This stub is required to support jump tables in BSPL.  It pushes
+; the absolute address of the jump table onto the data stack.
+; 
+; jump-table: foo will compile a call to this procedure.
+; Use jump-entries: to compile jump instructions to appropriate
+; entries.
+
+__jumptable__:	addi	dsp, dsp, -8	; Push address of jump table
+		sd	t0, 0(dsp)
+		jalr	x0, 0(ra)
+
+; The call procedure is used to invoke a dynamically determined
+; procedure.
+;
+; call ( ... proc -- ... )
+
+call:		ld	x16, 0(dsp)
+		addi	dsp, dsp, 8
+		jalr	x0, 0(x16)
+
 ; Configures the CPU to run BSPL code.  We need to reset the stack pointers
 ; and the global variable vector pointer.
 

--- a/3/src/stsv1/bspl-abi/bspl-suffix.asm
+++ b/3/src/stsv1/bspl-abi/bspl-suffix.asm
@@ -1,0 +1,24 @@
+; This Source Code Form is subject to the terms of the Mozilla Public
+; License, v. 2.0. If a copy of the MPL was not distributed with this
+; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+; THIS MUST BE THE LAST FILE IN THE STS IMAGE.
+
+; exits the emulator if we're running inside of one;
+; otherwise, deadlocks the machine.
+
+bye:            addi    rsp, rsp, -8
+                sd      x0, 0(rsp)
+                csrrw   x0, rsp, mtohost
+                jal     x0, *
+
+; Configures the CPU to run BSPL code.  We need to reset the stack pointers
+; and the global variable vector pointer.
+
+__cold__:       addi    dsp, x0, $0400	; DSP -> $0400 ($0000..$03FF)
+                add     rsp, dsp, dsp	; RSP -> $0800 ($0400..$07FF)
+                add     gvp, rsp, rsp	; GVP -> $1000 ($0800..$17FF)
+                jal     x0, _
+
+                adv     $FFF00, $CC
+                jal     x0, __cold__

--- a/3/src/stsv1/bspl-abi/csrs.i
+++ b/3/src/stsv1/bspl-abi/csrs.i
@@ -1,0 +1,86 @@
+; This Source Code Form is subject to the terms of the Mozilla Public
+; License, v. 2.0. If a copy of the MPL was not distributed with this
+; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+; Configuration and Status Registers.
+; Note: Not all registers may be implemented in hardware.
+; Not all registers may be implemented in the emulator either.
+; Always consult mcpuid and mimpid for supported features.
+
+; Machine-Mode CSRs
+
+mcpuid          = $F00
+mimpid          = $F01
+mhartid         = $F10
+mstatus         = $300
+mtvec           = $301
+mtdeleg         = $302
+mie             = $304
+mtimecmp        = $321
+mtime           = $701
+mtimeh          = $741
+mscratch        = $340
+mepc            = $341
+mcause          = $342
+mbadaddr        = $343
+mip             = $344
+mbase           = $380
+mbound          = $381
+mibase          = $382
+mibound         = $383
+mdbase          = $384
+mdbound         = $385
+htimew          = $B01
+htimehw         = $B81
+mtohost         = $780
+mfromhost       = $781
+
+; Hypervisor-Mode CSRs
+
+hstatus         = $200
+htvec           = $201
+htdeleg         = $202
+htimecmp        = $221
+htime           = $E01
+htimeh          = $E81
+hscratch        = $240
+hepc            = $241
+hcause          = $242
+hbadaddr        = $243
+stimew          = $A01
+stimehw         = $A81
+
+; Supervisor-Mode CSRs
+
+sstatus		= $100
+stvec		= $101
+sie		= $104
+stimecmp	= $121
+stime		= $D01
+stimeh		= $D81
+sscratch	= $140
+sepc		= $141
+scause		= $D42
+sbadaddr	= $D43
+sip		= $144
+sptbr		= $180
+sasid		= $181
+cyclew		= $900
+timew		= $901
+instretw	= $902
+cyclehw		= $980
+timehw		= $981
+instrethw	= $982
+
+; User-Mode CSRs
+
+fflags          = $001
+frm             = $002
+fcsr            = $003
+cycle           = $C00
+time            = $C01
+instret         = $C02
+cycleh          = $C80
+timeh           = $C81
+instreth        = $C82
+

--- a/3/src/stsv1/bspl-abi/regs.i
+++ b/3/src/stsv1/bspl-abi/regs.i
@@ -1,0 +1,39 @@
+; This Source Code Form is subject to the terms of the Mozilla Public
+; License, v. 2.0. If a copy of the MPL was not distributed with this
+; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+; Register Definitions
+
+ x0 =  0
+ x1 =  1
+ x2 =  2
+ x3 =  3
+ x4 =  4
+ x5 =  5
+ x6 =  6
+ x7 =  7
+ x8 =  8
+ x9 =  9
+x10 = 10
+x11 = 11
+x12 = 12
+x13 = 13
+x14 = 14
+x15 = 15
+x16 = 16
+x17 = 17
+x18 = 18
+x19 = 19
+x20 = 20
+x21 = 21
+x22 = 22
+x23 = 23
+x24 = 24
+x25 = 25
+x26 = 26
+x27 = 27
+x28 = 28
+x29 = 29
+x30 = 30
+x31 = 31
+

--- a/3/src/stsv1/bspl-abi/vectors.i
+++ b/3/src/stsv1/bspl-abi/vectors.i
@@ -1,0 +1,19 @@
+; This Source Code Form is subject to the terms of the Mozilla Public
+; License, v. 2.0. If a copy of the MPL was not distributed with this
+; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+; The CPU jumps unconditionally to one of the TRAP_FROM_x addresses whenever
+; an interrupt or exception occurs.  Which vector the CPU uses depends on
+; which operating mode it was operating in at the time the trap was taken.
+
+DEFAULT_TRAP_BASE       = $FFFFFFFFFFFFFE00
+TRAP_FROM_U             = $00
+TRAP_FROM_S             = $40
+TRAP_FROM_H             = $80
+TRAP_FROM_M             = $C0
+
+; The Polaris CPU always starts execution at this address after hard reset.
+; The MTVEC CSR will be set to DEFAULT_TRAP_BASE by default.
+
+RESET_BASE              = $FFFFFFFFFFFFFF00
+

--- a/3/src/stsv1/default.asm.do
+++ b/3/src/stsv1/default.asm.do
@@ -1,0 +1,4 @@
+redo-ifchange ../../bin/bspl.fs
+redo-ifchange $2.bs
+
+bspl.fs $(pwd)/$2.bs >$3

--- a/3/src/stsv1/default.rom.do
+++ b/3/src/stsv1/default.rom.do
@@ -1,0 +1,4 @@
+redo-ifchange ../../bin/a
+redo-ifchange $2.rom.asm $2.asm
+
+a from $2.rom.asm to $3 quiet

--- a/3/src/stsv1/stsv1.bs
+++ b/3/src/stsv1/stsv1.bs
@@ -16,5 +16,160 @@ extern bye
 \ Various console control characters.
 : cr ( - )	d# 13 >d emit d# 10 >d emit ;
 
-\ Luke-warm boot.
-: _		S" Booting STS V1.5" >d >d type cr bye ;
+: shr4		d> u2/ u2/ u2/ u2/ >d ;
+: shr15		shr4 shr4 shr4 d> u2/ u2/ u2/ >d ;
+: shr30		shr15 shr15 ;
+: shl4		d> 2* 2* 2* 2* >d ;
+: _1		d> S" 0123456789ABCDEF" nip + c@ >d emit ;
+: _4		0 d@ >d shr30 shr30 _1  shl4 ;
+: _16		_4 _4 _4 _4 ;
+: _64		_16 _16 _16 _16 d> ;
+
+\ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+\ These routines provide a dynamic memory management facility, allowing
+\ applications to request blocks of memory of a given size, and to release it
+\ later if required.
+\ 
+\ Pools are maintained through a singly linked, circular list of nodes with
+\ the invariant that a node N can point to node M if and only if M appears at
+\ a higher address than N, and which follows N immediately.  So, if looking at
+\ a memory dump of three nodes, A, B, and C in that order, A generally cannot
+\ point directly to C.  The sole exception is if A and B both represent free
+\ chunks of memory, where B's space coalesces with A to reduce fragmentation.
+\ An order like A, C, B is simply right out, no matter what.  If this happens,
+\ the memory pool is corrupted, and will inevitably lead to a crash.
+\ 
+\ The structure of a node follows (offsets in cells):
+\ 
+\ +0	next		Pointer to next node in the list, or back to first
+\			node.
+\ 
+\ +1	--1111....	The size of the allocation, in bytes, excluding the
+\			header.  Note that memory may not be requested in
+\			units smaller than sixteen bytes.
+\ 
+\ +1	--....111.	Unused bits.  Must be set to zero on writing, and
+\			ignored on read.
+\ 
+\ +1	--.......1	1=block is allocated; 0=block is free.
+
+dword: mplsta	\ Memory Pool Start
+dword: mplsiz	\ Memory Pool Size
+
+\ fmtmem formats a memory pool with the required metadata to support
+\ allocation requests.  The mplsta variable must point to the start of the
+\ memory pool, while mplsiz must contain its size, in bytes.  fmtmem does not
+\ return, and cannot fail.
+\
+\ Beware: formatting a pool that's been previously used will, in effect,
+\ forcefully deallocate everything from that pool.
+
+: fmtmem ( a u -- )
+	d> mplsiz ! d> mplsta !
+	mplsta @ mplsta @ !	( circular list node points to itself )
+	mplsiz @ d# -16 and d# 16 -	( size of first free block )
+	mplsta @ d# 8 + ! ;
+
+\ getmem allocates at least u bytes of memory.  If successful it returns the
+\ address of the allocated block, and a success flag.  Otherwise, undefined
+\ results and a false flag are returned.
+
+: gmsplit ( u a -- u a )
+	\ Make sure that it makes sense to split.
+	\ The current space must hold at least one header and
+	\ one 16 byte block, totalling 32 bytes, after splitting.
+	1 d@ d# 32 + 0 d@ d# 8 + @ d# -16 and -
+	-if
+S" GMSPLIT:" >d >d type cr
+		0 d@ 1 d@ + d# 16 + >d		( addr of next block )
+	  S" ADDR OF SPLIT BLOCK: " >d >d type 0 d@ >d _64 cr
+			1 d@ @ 0 d@ !		( link to next block )
+	  S" ADDR OF NEXT BLOCK: " >d >d type 0 d@ @ >d _64 cr
+			1 d@ d# 8 + @  2 d@ - d# 16 -
+				0 d@ d# 8 + !	( size of next block )
+	  S" SIZE OF NEXT BLOCK: " >d >d type 0 d@ d# 8 + @ >d _64 cr
+			0 d@  1 d@ !		( this blk -> next )
+			2 d@ d# 1 or  1 d@ d# 8 + !
+	  S" UPDATE THIS BLOCK: " >d >d type 1 d@ @ >d _64 cr
+	  S" RESIZED THIS BLOCK: " >d >d type 1 d@ d# 8 + @ >d _64 cr
+		d>
+	then ;
+
+: getmem ( u -- a -1 | ? 0 )
+	d> d# 15 + d# -16 and >d	( round to at least 16 bytes )
+
+	mplsta @ >d
+
+	begin ( u a )
+		\ Search for a free block.
+
+S" BEGIN: " >d >d type space 0 d@ >d _64 cr
+
+		begin 0 d@ d# 8 + @ d# 1 and while
+S"   ALLOCATED.  " >d >d type
+			d> @ >d				( next mem block )
+S" Trying " >d >d type 0 d@ >d _64 cr
+			0 d@ mplsta @ xor 0=if		( all blocks alloc'ed )
+				d# 0 0 d! exit
+			then
+		repeat
+
+S" SELECTED: " >d >d type space 0 d@ >d _64 cr
+
+		\ here, 0 d@ points to a free block.
+		\ It still might be too small though.
+
+		0 d@ d# 8 + @ d# -16 and  1 d@ -  +if	( block is big enough )
+			gmsplit
+			0 d@ d# 16 + 1 d!  d# -1 0 d!  exit
+		then
+
+S" TOO SMALL.  " >d >d type
+
+		\ Block too small, try the next block.
+
+		d> @ >d
+S" Trying " >d >d type 0 d@ >d _64 cr
+		0 d@ mplsta @ xor 0=if d# 0 0 d! exit then
+	again ;
+
+\ fremem releases a block of memory, whose pointer was returned by the
+\ getmem procedure.
+
+: fremem ( a -- )
+	d> d# 16 - >d		( recover header address )
+	0 d@ d# 8 + @ d# -2 and	( clear allocated bit )
+	d> d# 8 + ! ;
+
+
+\ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+\ Luke-warm boot.  After BSPL's start-up code completes, it jumps to _
+\ (yes, that's a single underscore).  BSPL's runtime does not expect _ to
+\ return.
+
+: banner	S" Booting STS V1.5" >d >d type cr ;
+: mem0		h# 2000 >d  d# 16777216 d# 8192 - >d fmtmem ;
+		( Nexys2 has 16MB of on-board RAM )
+
+: get0		d# 1024 >d getmem
+		d> 0=if S" expected non-null address from getmem" >d >d type cr bye then
+		0 d@ h# 2010 xor if S" Expected block at $2010, got:" >d >d type _64 cr bye then ;
+: get1		d# 1024 >d getmem
+		d> 0=if S" expected non-null addr from getmem 2" >d >d type cr bye then
+		0 d@ h# 2420 xor if S" Expected block at $2420, got:" >d >d type _64 cr bye then ;
+: get2		d# 1024 >d getmem
+		d> 0=if S" expected non-null addr from getmem 3" >d >d type cr bye then
+		0 d@ h# 2830 xor if S" Expected block at $2830, got:" >d >d type _64 cr bye then ;
+: get3		d# 1024 >d getmem
+		d> 0=if S" expected non-null addr from getmem 4" >d >d type cr bye then
+		0 d@ h# 2420 xor if S" Expected block at $2420 (get3), got:" >d >d type _64 cr bye then ;
+: fre1		h# 2420 >d fremem ;
+: fre0		h# 2010 >d fremem ;
+: get4		d# 2048 >d getmem
+		d> 0=if S" expected non-null address from getmem 5" >d >d type cr bye then
+		0 d@ h# 2010 xor if S" Expected 2K block at $2010 (get4), got:" >d >d type _64 cr bye then ;
+
+: memtest	get0 get1 get2 fre1 get3 fre1 fre0 S" ----" >d >d type cr get4 ;
+: _		cr banner mem0 memtest bye ;

--- a/3/src/stsv1/stsv1.bs
+++ b/3/src/stsv1/stsv1.bs
@@ -1,0 +1,20 @@
+\ Exits the emulator with return code 0.
+extern bye
+
+\ Sends the character to the user's console.
+: emit ( ch - )
+	d> d# $0E00000000000000 c! ;
+
+\ Takes the tail of a string.
+: nextch ( addr len - addr+1 len-1 )
+	d> d> d# 1 + >d d# 1 - >d ;
+
+\ Sends a string of length len to the console.
+: type ( addr len - )
+	begin 0 d@ while 1 d@ c@ >d emit nextch repeat d> d> drop drop ;
+
+\ Various console control characters.
+: cr ( - )	d# 13 >d emit d# 10 >d emit ;
+
+\ Luke-warm boot.
+: _		S" Booting STS V1.5" >d >d type cr bye ;

--- a/3/src/stsv1/stsv1.bs
+++ b/3/src/stsv1/stsv1.bs
@@ -1,6 +1,9 @@
 \ Exits the emulator with return code 0.
 extern bye
 
+\ Supports vectored execution.
+extern call
+
 \ Sends the character to the user's console.
 : emit ( ch - )
 	d> d# $0E00000000000000 c! ;
@@ -182,14 +185,7 @@ dword: mplsiz	\ Memory Pool Size
 
 
 \ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
-
-\ Luke-warm boot.  After BSPL's start-up code completes, it jumps to _
-\ (yes, that's a single underscore).  BSPL's runtime does not expect _ to
-\ return.
-
-: banner	S" Booting STS V1.5" >d >d type cr ;
-: mem0		h# 2000 >d  d# 16777216 d# 8192 - >d fmtmem ;
-		( Nexys2 has 16MB of on-board RAM )
+\ This code is a test suite for getmem and fremem.
 
 : get0		d# 1024 >d getmem
 		d> 0=if S" expected non-null address from getmem" >d >d type cr bye then
@@ -221,4 +217,24 @@ dword: mplsiz	\ Memory Pool Size
 : fre3		h# 2C40 >d fremem ;
 
 : memtest	get0 get1 get2 fre1 get3 fre1 fre0 get4 get5 fre0 fre3 fre2 get6 ;
-: _		cr banner mem0 memtest bye ;
+
+
+\ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+\ Luke-warm boot.  After BSPL's start-up code completes, it jumps to _
+\ (yes, that's a single underscore).  BSPL's runtime does not expect _ to
+\ return.
+
+: banner	S" Booting STS V1.5" >d >d type cr ;
+: mem0		h# 2000 >d  d# 16777216 d# 8192 - >d fmtmem ;
+		( Nexys2 has 16MB of on-board RAM )
+
+: procA		S" Procedure A" >d >d ;
+: procB		S" Procedure B" >d >d ;
+jump-table: jumptab
+jump-entries: procA procB ;
+: testA		jumptab d> d# 0 + >d call type cr ;
+: testB		jumptab d> d# 4 + >d call type cr ;
+
+
+: _		cr banner mem0 memtest testA testB bye ;

--- a/3/src/stsv1/stsv1.bs
+++ b/3/src/stsv1/stsv1.bs
@@ -94,6 +94,9 @@ S" GMSPLIT:" >d >d type cr
 	  S" UPDATE THIS BLOCK: " >d >d type 1 d@ @ >d _64 cr
 	  S" RESIZED THIS BLOCK: " >d >d type 1 d@ d# 8 + @ >d _64 cr
 		d>
+	else
+		( Too small to split; just mark whole thing allocated )
+		0 d@ d# 8 + @  d# 1 or  0 d@ d# 8 + !
 	then ;
 
 : getmem ( u -- a -1 | ? 0 )
@@ -104,21 +107,53 @@ S" GMSPLIT:" >d >d type cr
 	begin ( u a )
 		\ Search for a free block.
 
-S" BEGIN: " >d >d type space 0 d@ >d _64 cr
+		S" BEGIN: " >d >d type space 0 d@ >d _64 cr
 
 		begin 0 d@ d# 8 + @ d# 1 and while
-S"   ALLOCATED.  " >d >d type
+			S"   ALLOCATED.  " >d >d type
 			d> @ >d				( next mem block )
-S" Trying " >d >d type 0 d@ >d _64 cr
+			S" Trying " >d >d type 0 d@ >d _64 cr
 			0 d@ mplsta @ xor 0=if		( all blocks alloc'ed )
 				d# 0 0 d! exit
 			then
 		repeat
 
-S" SELECTED: " >d >d type space 0 d@ >d _64 cr
+		S" SELECTED: " >d >d type space 0 d@ >d _64 cr
 
 		\ here, 0 d@ points to a free block.
 		\ It still might be too small though.
+		\ Let's try to coalesce with an adjacent
+		\ free block, if one exists.
+
+		0 d@ @ >d d# 1 >d ( a b continue )
+		begin 0 d@ while
+			S"   CONSIDERING: " >d >d type 1 d@ >d _64
+			1 d@ mplsta @ xor 0=if
+				S" ..END OF POOL" >d >d type
+				d> d# 0 >d
+			else
+			1 d@ d# 8 + @ d# 1 and if
+				\ Adjacent block is allocated; stop coalescing
+				S" ..ADJACENT BLOCK ALLOC" >d >d type
+				d> d# 0 >d
+			else
+				S" ..COALESCING" >d >d type
+				\ Assimilate node b's total size.
+				d# 16		( size of b's header )
+				1 d@ d# 8 + @ + ( size of b's block )
+				2 d@ d# 8 + @ + ( size of a's block )
+				2 d@ d# 8 + !
+
+				\ Fix linkage
+				1 d@ @ 2 d@ !	( a.next = b.next )
+				1 d@ @ 1 d!	( b = b.next )
+			then then
+			cr
+		repeat
+		d> d>	( Discard continue flag and node b reference )
+
+		\ We have as large a free block as we can get.
+		\ Let's hope for the best.
 
 		0 d@ d# 8 + @ d# -16 and  1 d@ -  +if	( block is big enough )
 			gmsplit
@@ -138,9 +173,31 @@ S" Trying " >d >d type 0 d@ >d _64 cr
 \ getmem procedure.
 
 : fremem ( a -- )
+	\ Clear allocated bit.
+
 	d> d# 16 - >d		( recover header address )
-	0 d@ d# 8 + @ d# -2 and	( clear allocated bit )
-	d> d# 8 + ! ;
+	0 d@ d# 8 + @ d# -16 and 0 d@ d# 8 + !
+
+	\ Coalesce free blocks of memory downstream.
+
+	0 d@ @ >d ( a b )
+	begin 0 d@ d# 8 + @ d# 1 and d# 1 xor while
+		\ Assimilate node b's total size.
+		d# 16		( size of b's header )
+		0 d@ d# 8 + @ + ( size of b's block )
+		1 d@ d# 8 + @ + ( size of a's block )
+		1 d@ d# 8 + !
+
+		\ Fix linkage
+		0 d@ @ 1 d@ !	( a.next = b.next )
+		0 d@ @ 0 d!	( b = b.next )
+
+		\ Early exit if we reach end of memory list
+		0 d@ mplsta @ xor 0=if
+			d> d> exit
+		then
+	repeat
+	d> d> ;
 
 
 \ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
@@ -165,11 +222,23 @@ S" Trying " >d >d type 0 d@ >d _64 cr
 : get3		d# 1024 >d getmem
 		d> 0=if S" expected non-null addr from getmem 4" >d >d type cr bye then
 		0 d@ h# 2420 xor if S" Expected block at $2420 (get3), got:" >d >d type _64 cr bye then ;
-: fre1		h# 2420 >d fremem ;
-: fre0		h# 2010 >d fremem ;
+
 : get4		d# 2048 >d getmem
 		d> 0=if S" expected non-null address from getmem 5" >d >d type cr bye then
 		0 d@ h# 2010 xor if S" Expected 2K block at $2010 (get4), got:" >d >d type _64 cr bye then ;
+: get5		d# 2048 >d getmem
+		d> 0=if S" expected non-null address from getmem 6" >d >d type cr bye then
+		0 d@ h# 2C40 xor if S" Expected 2K block at $2C40 (get5), got:" >d >d type _64 cr bye then ;
+: get6		d# 1048576 >d getmem
+		d> 0=if S" expected non-null address from getmem 7" >d >d type cr bye then
+		0 d@ h# 2010 xor if S" Expected 1M block at $2010 (get6), got:" >d >d type _64 cr bye then ;
 
-: memtest	get0 get1 get2 fre1 get3 fre1 fre0 S" ----" >d >d type cr get4 ;
+
+: fre0		h# 2010 >d fremem ;
+: fre1		h# 2420 >d fremem ;
+: fre2		h# 2830 >d fremem ;
+: fre3		h# 2C40 >d fremem ;
+
+: m____		S" ----" >d >d type cr ;
+: memtest	get0 get1 get2 m____ fre1 get3 m____ fre1 fre0 m____ get4 get5 m____ fre0 fre3 fre2 get6 ;
 : _		cr banner mem0 memtest bye ;

--- a/3/src/stsv1/stsv1.bs
+++ b/3/src/stsv1/stsv1.bs
@@ -81,18 +81,12 @@ dword: mplsiz	\ Memory Pool Size
 	\ one 16 byte block, totalling 32 bytes, after splitting.
 	1 d@ d# 32 + 0 d@ d# 8 + @ d# -16 and -
 	-if
-S" GMSPLIT:" >d >d type cr
 		0 d@ 1 d@ + d# 16 + >d		( addr of next block )
-	  S" ADDR OF SPLIT BLOCK: " >d >d type 0 d@ >d _64 cr
 			1 d@ @ 0 d@ !		( link to next block )
-	  S" ADDR OF NEXT BLOCK: " >d >d type 0 d@ @ >d _64 cr
 			1 d@ d# 8 + @  2 d@ - d# 16 -
 				0 d@ d# 8 + !	( size of next block )
-	  S" SIZE OF NEXT BLOCK: " >d >d type 0 d@ d# 8 + @ >d _64 cr
 			0 d@  1 d@ !		( this blk -> next )
 			2 d@ d# 1 or  1 d@ d# 8 + !
-	  S" UPDATE THIS BLOCK: " >d >d type 1 d@ @ >d _64 cr
-	  S" RESIZED THIS BLOCK: " >d >d type 1 d@ d# 8 + @ >d _64 cr
 		d>
 	else
 		( Too small to split; just mark whole thing allocated )
@@ -107,18 +101,12 @@ S" GMSPLIT:" >d >d type cr
 	begin ( u a )
 		\ Search for a free block.
 
-		S" BEGIN: " >d >d type space 0 d@ >d _64 cr
-
 		begin 0 d@ d# 8 + @ d# 1 and while
-			S"   ALLOCATED.  " >d >d type
 			d> @ >d				( next mem block )
-			S" Trying " >d >d type 0 d@ >d _64 cr
 			0 d@ mplsta @ xor 0=if		( all blocks alloc'ed )
 				d# 0 0 d! exit
 			then
 		repeat
-
-		S" SELECTED: " >d >d type space 0 d@ >d _64 cr
 
 		\ here, 0 d@ points to a free block.
 		\ It still might be too small though.
@@ -127,17 +115,13 @@ S" GMSPLIT:" >d >d type cr
 
 		0 d@ @ >d d# 1 >d ( a b continue )
 		begin 0 d@ while
-			S"   CONSIDERING: " >d >d type 1 d@ >d _64
 			1 d@ mplsta @ xor 0=if
-				S" ..END OF POOL" >d >d type
 				d> d# 0 >d
 			else
 			1 d@ d# 8 + @ d# 1 and if
 				\ Adjacent block is allocated; stop coalescing
-				S" ..ADJACENT BLOCK ALLOC" >d >d type
 				d> d# 0 >d
 			else
-				S" ..COALESCING" >d >d type
 				\ Assimilate node b's total size.
 				d# 16		( size of b's header )
 				1 d@ d# 8 + @ + ( size of b's block )
@@ -148,7 +132,6 @@ S" GMSPLIT:" >d >d type cr
 				1 d@ @ 2 d@ !	( a.next = b.next )
 				1 d@ @ 1 d!	( b = b.next )
 			then then
-			cr
 		repeat
 		d> d>	( Discard continue flag and node b reference )
 
@@ -160,12 +143,9 @@ S" GMSPLIT:" >d >d type cr
 			0 d@ d# 16 + 1 d!  d# -1 0 d!  exit
 		then
 
-S" TOO SMALL.  " >d >d type
-
 		\ Block too small, try the next block.
 
 		d> @ >d
-S" Trying " >d >d type 0 d@ >d _64 cr
 		0 d@ mplsta @ xor 0=if d# 0 0 d! exit then
 	again ;
 
@@ -239,6 +219,5 @@ S" Trying " >d >d type 0 d@ >d _64 cr
 : fre2		h# 2830 >d fremem ;
 : fre3		h# 2C40 >d fremem ;
 
-: m____		S" ----" >d >d type cr ;
-: memtest	get0 get1 get2 m____ fre1 get3 m____ fre1 fre0 m____ get4 get5 m____ fre0 fre3 fre2 get6 ;
+: memtest	get0 get1 get2 fre1 get3 fre1 fre0 get4 get5 fre0 fre3 fre2 get6 ;
 : _		cr banner mem0 memtest bye ;

--- a/3/src/stsv1/stsv1.bs
+++ b/3/src/stsv1/stsv1.bs
@@ -16,6 +16,7 @@ extern bye
 \ Various console control characters.
 : cr ( - )	d# 13 >d emit d# 10 >d emit ;
 
+\ For debugging, _64 is used to print a 64-bit value in hex.
 : shr4		d> u2/ u2/ u2/ u2/ >d ;
 : shr15		shr4 shr4 shr4 d> u2/ u2/ u2/ >d ;
 : shr30		shr15 shr15 ;

--- a/3/src/stsv1/stsv1.rom.asm
+++ b/3/src/stsv1/stsv1.rom.asm
@@ -1,0 +1,14 @@
+; This Source Code Form is subject to the terms of the Mozilla Public
+; License, v. 2.0. If a copy of the MPL was not distributed with this
+; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+; BSPL cannot produce direct-to-ROM-image binaries, so we need to wrap
+; its output in something that can.
+
+		include	"bspl-abi/csrs.i"
+		include "bspl-abi/regs.i"
+		include	"bspl-abi/bspl-regs.i"
+
+		include	"stsv1.asm"
+
+		include	"bspl-abi/bspl-suffix.asm"


### PR DESCRIPTION
Requires run-time support, but the code is trivially small.