### PR TITLE
Walk a tree of objects to find an object by name.

### DIFF
--- a/3/src/stsv1/compareNames.asm
+++ b/3/src/stsv1/compareNames.asm
@@ -1,0 +1,29 @@
+; Compare two names.  Return < 0 if string 1 collates ahead of string 2,
+; 0 if they're equal, or > 0 if string 1 collates after string 2.
+;
+; result = compareNames(str1, str2, len1, len2)
+;   A0                   A0    A1    A2    A3
+
+compareNames:	addi	rp, rp, -16
+		sd	rt, 0(rp)
+		sd	a2, 8(rp)
+
+		; Compare strings up to the shorter of their two lengths.
+		blt	a2, a3, cN_L1
+		addi	a2, a3, 0
+cN_L1:		jal	rt, compareNamesUpToLength
+
+		; If not equal, we just return the results immediately.
+		; Otherwise, all we know is that they have a common prefix.
+		bne	a0, x0, cN_L2
+
+		; The strings are truly equal if, and only if, they have
+		; common lengths.  Otherwise, the shorter string must collate
+		; ahead of the longer.
+		ld	a0, 8(rp)
+		sub	a0, a0, a3
+		
+cN_L2:		ld	rt, 0(rp)
+		ld	a2, 8(rp)
+		addi	rp, rp, 16
+		jalr	x0, 0(rt)

--- a/3/src/stsv1/compareNamesUpToLength.asm
+++ b/3/src/stsv1/compareNamesUpToLength.asm
@@ -1,0 +1,26 @@
+; Synopsis:
+;	result = compareNamesUpToLength(strA, strB, length)
+;	  A0                             A0    A1     A2
+;
+; Compare two memory buffers.  As soon as one discrepency exists, return a
+; signed integer, to be interpreted as follows:
+;
+; < 0 -- string pointed to by A0 collates ahead of string pointed to by A1
+; = 0 -- both strings match byte for byte
+; > 0 -- string pointed to by A0 collages after string pointed to by A1
+
+compareNamesUpToLength:
+		addi	t0, x0, 0
+cNUTL0:		bge	t0, a2, cNUTL1
+		add	t1, a0, t0		; T1, T2 -> bytes in strings
+		add	t2, a1, t0
+		lb	t1, 0(t1)		; T1, T2 = bytes in strings
+		lb	t2, 0(t2)
+		sub	t1, t1, t2		; T1 = difference
+		beq	t1, x0, cNUTL2
+		addi	a0, t1, 0		; T1 != 0, just return it.
+		jalr	x0, 0(ra)
+cNUTL2:		addi	t0, t0, 1		; T1 = 0, move to next byte
+		jal	x0, cNUTL0
+cNUTL1:		addi	a0, x0, 0		; No more chars, must be equal
+		jalr	x0, 0(ra)

--- a/3/src/stsv1/stsv1.bs
+++ b/3/src/stsv1/stsv1.bs
@@ -489,6 +489,11 @@ extern asmstrcmp
 : objWalk ( caddr u a -- a' -1 | ? 0 )
 	0 d@ >d objVTable call ;
 
+\ Disposes of the object.
+
+: objDispose ( a -- )
+	0 d@ >d objVTable d> d# 4 + >d call ;
+
 
 \ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
@@ -525,7 +530,7 @@ extern asmstrcmp
 \ object messages of similar names.
 
 jump-table: objDir_vtable
-jump-entries: objDirWalk ;
+jump-entries: objDirWalk objDirDispose ;
 
 \ Initializes an ObjDir.
 
@@ -568,9 +573,6 @@ jump-entries: objDirWalk ;
 \ to the depth of the sought resource.  If the object tree is
 \ malformed so that a cycle exists, this procedure will overflow your
 \ stack and crash the system.
-
-: objWalk ( caddr u a -- a' -1 | ? 0 )
-	0 d@ >d objVTable call ;
 
 : objDirWalk ( caddr u a -- a' -1 | ? 0 )
 	1 d@ 0=if	( null name? )
@@ -678,12 +680,12 @@ jump-entries: objDirWalk ;
 	1 d@ >d 7 d@ >d objDirAddHead
 	0 d@ >d 6 d@ >d objDirAddHead
 
-	S" sd2/sd3/sd4" >d >d 10 d@ >d objDirWalk
+	S" sd2/sd3/sd4" >d >d 10 d@ >d objWalk
 		d> 0=if S"   walk2: can't find sd4" >d >d type cr bye then
 		d> 4 d@ xor if S"   walk2: sd4 expected" >d >d type cr bye then
 
 	objEntDispose objEntDispose objEntDispose objEntDispose
-	objDirDispose objDirDispose objDirDispose objDirDispose objDirDispose ;
+	objDispose objDispose objDispose objDispose objDispose ;
 
 : objDirTest
 	S" objdir:" >d >d type cr

--- a/3/src/stsv1/stsv1.bs
+++ b/3/src/stsv1/stsv1.bs
@@ -185,6 +185,34 @@ dword: mplsiz	\ Memory Pool Size
 	repeat
 	d> d> ;
 
+\ Moves a block of memory from src to dst.  The block moved will consist
+\ of len bytes.  NOTE: Currently, it does not handle overlapping blocks
+\ of memory.  It implements a simple, slow, byte-granular, ascending
+\ memory move.
+
+: movmem ( src dst len -- )
+	begin
+		0 d@ 0=if d> d> d> exit then
+		2 d@ c@ 1 d@ c!
+		2 d@ d# 1 + 2 d!
+		1 d@ d# 1 + 1 d!
+		0 d@ d# 1 - 0 d!
+	again ;
+
+\ Sets a block of memory to an arbitrary byte value.
+
+: setmem ( dst len c -- )
+	begin
+		1 d@ 0=if d> d> d> exit then
+		0 d@ 2 d@ c!
+		2 d@ d# 1 + 2 d!
+		1 d@ d# 1 - 1 d!
+	again ;
+
+\ Zeros a block of memory.
+
+: zermem ( dst len -- )
+	d# 0 >d setmem ;
 
 \ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 \ This code is a test suite for getmem and fremem.
@@ -218,8 +246,260 @@ dword: mplsiz	\ Memory Pool Size
 : fre2		h# 2830 >d fremem ;
 : fre3		h# 2C40 >d fremem ;
 
-: memtest	get0 get1 get2 fre1 get3 fre1 fre0 get4 get5 fre0 fre3 fre2 get6 ;
+: memtest
+	S" memtest:" >d >d type cr
+	get0 get1 get2 fre1 get3 fre1 fre0 get4 get5 fre0 fre3 fre2 get6
+	S" OK" >d >d type cr ;
 
+\ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+\ Duplicate a string in memory.  The only way this can fail is
+\ if no memory is available for allocation; in this case, 0
+\ is returned.  Otherwise, a suitably sized block of memory
+\ is allocated, and the original string copied into it.  The
+\ address returned is that of the new string.
+\ 
+\ Note that the caller is responsible for invoking fremem on
+\ the duplicated string.
+
+: strDup ( caddr u -- caddr' -1 | ? 0 )
+	0 d@ >d getmem  0 d@ 0=if
+		d> d> d# 0 >d exit
+	then d>
+	1 d@ >d		( caddr u caddr' u )
+	3 d@ 2 d!	( caddr caddr caddr' u )
+	1 d@ 3 d!	( caddr' caddr caddr' u )
+	movmem d# -1 >d ;
+
+\ Return true if and only if the two strings match, including
+\ case.
+
+extern asmstrcmp
+
+: strEql ( a1 u1 a2 u2 -- -1 | 0 )
+	asmstrcmp d> 0=if d# -1 >d exit then
+	d# 0 >d ;
+
+\ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+\ ObjEnt objects bind a name to an STS object of some kind.
+\ +0	Name
+\ +8	Name Length
+\ +16	Pointer to next entity
+\ +24	Pointer to object
+
+32 const szObjEnt
+
+\ Initializes an object entry to default state.
+
+: objEntInit ( a -- a )
+	0 d@ >d  szObjEnt >d  zermem ;
+
+\ Answers the length of the name for the entity.
+
+: objEntNameLength ( a -- n )
+	d> d# 8 + @ >d ;
+
+\ Answers the pointer to the entity name.
+
+: objEntNamePtr ( a -- a' )
+	d> @ >d ;
+
+\ Answers the next object in the entity chain, if any.
+
+: objEntNext ( a -- a' )
+	d> d# 16 + @ >d ;
+
+\ Answers the object that the entity names.
+
+: objEntObject ( a -- a' )
+	d> d# 24 + @ >d ;
+
+\ Sets the object that the entity binds.
+
+: objEntSetObject ( a' a -- )
+	d> d# 24 + d> swap ! ;
+
+\ Creates a new entity.
+
+: objEntNew ( -- a -1 | ? 0 )
+	szObjEnt >d getmem 0 d@ 0=if exit then d> 
+	objEntInit d# -1 >d ;
+
+\ Disposes of an entity allocated by objEntNew.
+
+: objEntDispose ( a -- )
+	0 d@ @ if 0 d@ @ fremem then	( free name )
+	fremem ;
+
+\ Changes the name of the entity.
+\ NOTE: Currently, you are responsible for freeing the original
+\ name.  Changing the name without doing so will leak memory.
+
+: objEntSetName ( caddr u a -- -1 | 0 )
+	1 d@ 0 d@ d# 8 + !	( set length )
+	2 d@ >d 2 d@ >d strDup d> 0=if
+		d> d> d> d>
+		d# 0 >d exit
+	then
+	d> d> !		( set name pointer )
+	d> d> d# -1 >d ;
+
+\ Answers the name of the entity.
+
+: objEntName ( a -- caddr u )
+	0 d@ >d objEntNameLength
+	1 d@ @ 1 d! ;
+
+\ Answers true if the entity possesses the given name.
+
+: objEntIsNamed ( caddr u a -- -1 | 0 )
+	objEntName strEql ;
+
+: objEntTCreation
+	objEntNew 0 d@ 0=if S"   creation: failed" >d >d type cr bye then d>
+	objEntDispose ;
+
+: _testName
+	S" testName" >d >d ;
+
+: objEntTName
+	objEntNew 0 d@ 0=if S"   name: creation" >d >d type cr bye then d>
+	_testName 2 d@ >d objEntSetName d> 0=if S"   name: set name" >d >d type cr bye then
+	0 d@ >d objEntName
+		d> d# 8 xor if S"   name: length mismatch" >d >d type cr bye then
+		_testName d> d> d> xor 0=if S"   name: not copied" >d >d type cr bye then
+	0 d@ >d objEntName _testName strEql d> 0=if S"   name: not equal" >d >d type cr bye then
+	objEntDispose ;
+
+: objEntTest
+	S" ObjEnt:" >d >d type cr
+	objEntTCreation objEntTName
+	S" OK" >d >d type cr ;
+
+\ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+\ ObjDir objects map names to other (compatible) objects.  These
+\ form the basis for STS' filesystem abstraction.  They are
+\ essentially singly-linked lists of name->object pairs that
+\ happens to also know which ObjDir is its container.
+\ 
+\ +0	Parent
+\ +8	Pointer to first ObjEnt record, or NULL.
+
+16 const szObjDir
+
+\ Answers the directory's parent.  If the directory is the root
+\ directory, it will answer itself.
+
+: objDirParent ( a -- a' )
+	d> @ >d ;
+
+\ Answers the first ObjEnt assigned to the directory.
+
+: objDirFirst ( a -- a' )
+	d> d# 8 + @ >d ;
+
+\ Initializes an ObjDir.
+
+: objDirInit ( a -- a )
+	0 d@ >d szObjDir >d zermem
+	0 d@ 0 d@ ! ;		( we're a root directory )
+
+\ Creates a new ObjDir directory object.
+
+: objDirNew ( -- a -1 | ? 0 )
+	szObjDir >d getmem 0 d@ 0=if exit then d>
+	objDirInit d# -1 >d ;
+
+\ Disposes of the object directory.  You should remove all
+\ mounts before calling this procedure, or you will leak
+\ memory.
+
+: objDirDispose ( a -- )
+	fremem ;
+
+\ Adds an ObjEnt to the head of the ObjDir's list of bindings.
+
+: objDirAddHead ( e a -- )
+	0 d@ >d objDirFirst d> 1 d@ d# 16 + !	( set next field )
+	d> d# 8 + d> swap ! ;
+
+\ Removes an ObjEnt from the head of the ObjDir's binding list.
+
+: objDirRemHead ( a -- a' )
+	0 d@ >d objDirFirst
+	0 d@ >d objEntNext  d> 1 d@ d# 8 + !
+	d> 0 d! ;
+
+\ Walks the object hierarchy by name, and if the named resource is
+\ found, return it and a true flag.  Otherwise, return a false flag.
+
+: objDirWalk ( caddr u a -- a' -1 | ? 0 )
+	1 d@ 0=if	( null name? )
+		0 d@ 2 d!  d# -1 1 d!  d>  exit
+	then
+	objDirFirst begin 0 d@ while
+		2 d@ >d 2 d@ >d 2 d@ >d objEntIsNamed d> if
+			objEntObject d> 1 d!  d# -1 0 d! exit
+		then
+		objEntNext
+	repeat d# 0 1 d! d> ;
+
+: objDirTCreate
+	objDirNew d> 0=if S"   create: failed" >d >d type cr bye then
+	objDirDispose ;
+
+: objDirTParent
+	objDirNew d> 0=if S"   parent: creation" >d >d type cr bye then
+	0 d@ >d objDirParent d> 0 d@ xor if S"   parent: expected root dir" >d >d type cr bye then
+	objDirDispose ;
+
+: objDirTEmpty
+	objDirNew d> 0=if S"  empty: creation" >d >d type cr bye then
+	0 d@ >d objDirFirst d> if S"   empty: content unexpected" >d >d type cr bye then
+	objDirDispose ;
+
+: objDirTFirst
+	objDirNew d> 0=if S"   first: creation" >d >d type cr bye then
+	objEntNew d> 0=if S"   first: entity" >d >d type cr bye then
+	S" woohoo" >d >d 2 d@ >d objEntSetName d> 0=if S"   first: entity name" >d >d type cr bye then
+	h# DEADBEEF >d 1 d@ >d objEntSetObject
+	0 d@ >d 2 d@ >d objDirAddHead
+
+	1 d@ >d objDirFirst d> 0 d@ xor if S" first: mismatch" >d >d type cr bye then
+	1 d@ >d objDirRemHead d>
+	objEntDispose objDirDispose ;
+
+\ BSPL cannot record an empty string with S" ", so this procedure
+\ pushes a zero-length string onto the stack manually.
+: _emptystr
+	d# 0 >d d# 0 >d ;
+
+: objDirTWalk
+	objDirNew d> 0=if S"   walk: dir" >d >d type cr bye then
+
+	objEntNew d> 0=if S"   walk: ent" >d >d type cr bye then
+	S" woo" >d >d 2 d@ >d objEntSetName d> 0=if S"   walk: ent name" >d >d type cr bye then
+	h# 1111 >d 1 d@ >d objEntSetObject
+	0 d@ >d 2 d@ >d objDirAddHead
+
+	_emptystr 3 d@ >d objDirWalk
+		d> 0=if S" walk: can't find self" >d >d type cr bye then
+		d> 1 d@ xor if S"   walk: self expected" >d >d type cr bye then
+	S" woo" >d >d 3 d@ >d objDirWalk
+		d> 0=if S" walk: can't find woo" >d >d type cr bye then
+		d> h# 1111 xor if S"   walk: woo expected" >d >d type cr bye then
+	S" bar" >d >d 3 d@ >d objDirWalk
+		d> if S" walk: missing file found?" >d >d type cr bye then
+		d>
+
+	objEntDispose objDirDispose ;
+	
+: objDirTest
+	S" objdir:" >d >d type cr
+	objDirTCreate objDirTParent objDirTEmpty objDirTFirst objDirTWalk
+	S" OK" >d >d type cr ;
 
 \ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
@@ -340,5 +620,6 @@ dword: re	( points just beyond last character )
 : mem0		h# 2000 >d  d# 16777216 d# 8192 - >d fmtmem ;
 		( Nexys2 has 16MB of on-board RAM )
 
-: _		cr banner mem0 memtest romshell bye ;
+: selfTest	memtest objEntTest objDirTest ;
+: _		cr banner mem0 selfTest romshell bye ;
 

--- a/3/src/stsv1/stsv1.bs
+++ b/3/src/stsv1/stsv1.bs
@@ -460,42 +460,82 @@ extern asmstrcmp
 
 \ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
+\ Obj objects represent generic filing system objects in a
+\ unified name space.  ObjEnt structures refer to instances of
+\ Obj.  Depending on the nature of the object, they could be
+\ ObjDir, ObjFile, or some other Obj-derived entity.  Note that
+\ Obj *itself* is abstract, and cannot be instantiated in any
+\ meaningful sense on its own.  See ObjDir (below) for one way
+\ to refine Obj into something reifiable.
+
+\ Obj objects consist of a single field: a pointer to a jump
+\ table.
+
+8 const szObj
+
+\ Answers the object's jump table.
+
+: objVTable ( a -- a' )
+	d> @ >d ;
+
+\ Walks the object hierarchy by name, and if the named resource is
+\ found, return it and a true flag.  Otherwise, return a false flag.
+\
+\ Note that this procedure is recursive; it uses memory in proportion
+\ to the depth of the sought resource.  If the object tree is
+\ malformed so that a cycle exists, this procedure will overflow your
+\ stack and crash the system.
+
+: objWalk ( caddr u a -- a' -1 | ? 0 )
+	0 d@ >d objVTable call ;
+
+
+\ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
 \ ObjDir objects map names to other (compatible) objects.  These
 \ form the basis for STS' filesystem abstraction.  They are
 \ essentially singly-linked lists of name->object pairs that
 \ happens to also know which ObjDir is its container.
 \ 
-\ +0	Parent
-\ +8	Pointer to first ObjEnt record, or NULL.
+\ +0	VTable
+\ +8	Parent
+\ +16	Pointer to first ObjEnt record, or NULL.
 
-16 const szObjDir
+24 const szObjDir
 
 \ Answers the directory's parent.  If the directory is the root
 \ directory, it will answer itself.
 
 : objDirParent ( a -- a' )
-	d> @ >d ;
-
+	d> d# 8 + @ >d ;
 
 \ Assigns the object a new parent.  Objects can belong to only 
 \ one parent.
 
 : objDirSetParent ( p a -- )
-	d> d> swap ! ;
-
+	d> d# 8 + d> swap ! ;
 
 \ Answers the first ObjEnt assigned to the directory.
 
 : objDirFirst ( a -- a' )
-	d> d# 8 + @ >d ;
+	d> d# 16 + @ >d ;
+
+\ Objects are polymorphic in some circumstances.  The following
+\ jump table provides linkage to the methods corresponding to
+\ object messages of similar names.
+
+jump-table: objDir_vtable
+jump-entries: objDirWalk ;
 
 \ Initializes an ObjDir.
 
 : objDirInit ( a -- a )
 	0 d@ >d szObjDir >d zermem
-	0 d@ 0 d@ ! ;		( we're a root directory )
+	objDir_vtable d> 0 d@ !				( vtable )
+	0 d@ >d 0 d@ >d objDirSetParent ;		( we're a root directory )
 
-\ Creates a new ObjDir directory object.
+\ Creates a new ObjDir directory object.  By default, it assumes
+\ it's a root directory.  Use objDirSetParent to change this.
 
 : objDirNew ( -- a -1 | ? 0 )
 	szObjDir >d getmem 0 d@ 0=if exit then d>
@@ -512,13 +552,13 @@ extern asmstrcmp
 
 : objDirAddHead ( e a -- )
 	0 d@ >d objDirFirst d> 1 d@ d# 16 + !	( set next field )
-	d> d# 8 + d> swap ! ;
+	d> d# 16 + d> swap ! ;
 
 \ Removes an ObjEnt from the head of the ObjDir's binding list.
 
 : objDirRemHead ( a -- a' )
 	0 d@ >d objDirFirst
-	0 d@ >d objEntNext  d> 1 d@ d# 8 + !
+	0 d@ >d objEntNext  d> 1 d@ d# 16 + !
 	d> 0 d! ;
 
 \ Walks the object hierarchy by name, and if the named resource is
@@ -529,6 +569,9 @@ extern asmstrcmp
 \ malformed so that a cycle exists, this procedure will overflow your
 \ stack and crash the system.
 
+: objWalk ( caddr u a -- a' -1 | ? 0 )
+	0 d@ >d objVTable call ;
+
 : objDirWalk ( caddr u a -- a' -1 | ? 0 )
 	1 d@ 0=if	( null name? )
 		0 d@ 2 d!  d# -1 1 d!  d>  exit
@@ -538,7 +581,7 @@ extern asmstrcmp
 		1 d@ >d 1 d@ >d 6 d@ >d objEntIsNamed d> if
 			3 d@ 6 d!  2 d@ 5 d!
 			d> d> d> d>
-			objEntObject objDirWalk exit
+			objEntObject objWalk exit
 		then
 		4 d@ >d objEntNext d> 4 d!
 	repeat d# 0 5 d! d> d> d> d> d> ;
@@ -766,6 +809,12 @@ dword: re	( points just beyond last character )
 : mem0		h# 2000 >d  d# 16777216 d# 8192 - >d fmtmem ;
 		( Nexys2 has 16MB of on-board RAM )
 
-: selfTest	memtest strTest objEntTest objDirTest ;
+jump-table: ctvt
+jump-entries: callTestProc banner ;
+
+: callTestProc	S" call:" >d >d type cr S" ok" >d >d type cr ;
+: callTest	ctvt call  ctvt d> d# 4 + >d call ;
+
+: selfTest	memtest callTest strTest objEntTest objDirTest ;
 : _		cr banner mem0 selfTest romshell bye ;
 

--- a/3/src/stsv1/stsv1.bs
+++ b/3/src/stsv1/stsv1.bs
@@ -252,6 +252,14 @@ dword: mplsiz	\ Memory Pool Size
 	S" OK" >d >d type cr ;
 
 \ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+\
+\ The string library maintains useful string-related procedures.
+
+
+\ BSPL cannot record an empty string with S" ", so this procedure
+\ pushes a zero-length string onto the stack manually.
+: _emptystr
+	d# 0 >d d# 0 >d ;
 
 \ Duplicate a string in memory.  The only way this can fail is
 \ if no memory is available for allocation; in this case, 0
@@ -279,6 +287,79 @@ extern asmstrcmp
 : strEql ( a1 u1 a2 u2 -- -1 | 0 )
 	asmstrcmp d> 0=if d# -1 >d exit then
 	d# 0 >d ;
+
+\ Splits a string at the first slash, intended for filesystem
+\ navigation purposes.  This procedure always returns two strings.
+\ The table below explains the relationship between an input string
+\ I, and the resulting prefix string P and suffix string S:
+\
+\ I		P		S
+\ ""		""		""
+\ "/"		""		""
+\ "foo"		"foo"		""
+\ "foo/"	"foo"		""
+\ "/foo"	""		"foo"
+\ "/foo/"	""		"foo/"
+\ "foo/bar"	"foo"		"bar"
+\ "foo/bar/"	"foo"		"bar/"
+\ "///"		""		"//"
+
+: strSplitSlash ( ia iu -- sa su pa pu )
+	1 d@ >d d# 0 >d		( sa su pa pu )
+	begin
+		2 d@ 0=if exit then
+		3 d@ c@ char / lit, xor 0=if
+			2 d@ d# 1 - 2 d!
+			3 d@ d# 1 + 3 d!
+			exit
+		then
+		0 d@ d# 1 + 0 d!
+		2 d@ d# 1 - 2 d!
+		3 d@ d# 1 + 3 d!
+	again ;
+		
+: strTSplitEmpty
+	_emptystr strSplitSlash
+		d> if S"   splitEmpty: prefix length" >d >d type cr bye then d>
+		d> if S"   splitEmpty: suffix length" >d >d type cr bye then d>
+	S" /" >d >d strSplitSlash
+		d> if S"   splitEmpty: / prefix length" >d >d type cr bye then d>
+		d> if S"   splitEmpty: / suffix length" >d >d type cr bye then d> ;
+
+: strTSplitSlash
+	S" foo" >d >d strSplitSlash
+		d> d# 3 xor if S"   splitSlash: prefix length" >d >d type cr bye then
+		d# 3 >d S" foo" >d >d strEql d> 0=if S"   splitSlash: prefix" >d >d type cr bye then
+		d> if S"   splitSlash: suffix length" >d >d type cr bye then d>
+	S" foo/" >d >d strSplitSlash
+		d> d# 3 xor if S"   splitSlash: / prefix length" >d >d type cr bye then
+		d# 3 >d S" foo" >d >d strEql d> 0=if S"   splitSlash: / prefix" >d >d type cr bye then
+		d> if S"   splitSlash: / suffix length" >d >d type cr bye then d>
+	S" /foo" >d >d strSplitSlash
+		d> if S"   splitSlash: prefix length /foo" >d >d type cr bye then d>
+		d> d# 3 xor if S"   splitSlash: suffix length /foo" >d >d type cr bye then
+		d# 3 >d S" foo" >d >d strEql d> 0=if S"   splitSlash: suffix /foo" >d >d type cr bye then
+	S" /foo/" >d >d strSplitSlash
+		d> if S"   splitSlash: prefix length /foo/" >d >d type cr bye then d>
+		d> d# 4 xor if S"   splitSlash: suffix length /foo/" >d >d type cr bye then
+		d# 4 >d S" foo/" >d >d strEql d> 0=if S"   splitSlash: suffix /foo/" >d >d type cr bye then ;
+
+: strTSplitBlort
+	S" foo/blort" >d >d strSplitSlash
+		d> d# 3 xor if S"   splitBlort: prefix length" >d >d type cr bye then
+		d# 3 >d S" foo" >d >d strEql d> 0=if S"   splitBlort: prefix" >d >d type cr bye then
+		d> d# 5 xor if S"   splitBlort: suffix length" >d >d type cr bye then
+		d# 5 >d S" blort" >d >d strEql d> 0=if S"   splitBlort: suffix" >d >d type cr bye then
+	S" foo/blort/" >d >d strSplitSlash
+		d> d# 3 xor if S"   splitBlort: prefix length" >d >d type cr bye then
+		d# 3 >d S" foo" >d >d strEql d> 0=if S"   splitBlort: prefix" >d >d type cr bye then
+		d> d# 6 xor if S"   splitBlort: suffix length" >d >d type cr bye then
+		d# 6 >d S" blort/" >d >d strEql d> 0=if S"   splitBlort: suffix" >d >d type cr bye then ;
+
+: strTest
+	S" str:" >d >d type cr
+	strTSplitEmpty strTSplitSlash strTSplitBlort
+	S" OK" >d >d type cr ;
 
 \ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
@@ -329,7 +410,7 @@ extern asmstrcmp
 \ Disposes of an entity allocated by objEntNew.
 
 : objEntDispose ( a -- )
-	0 d@ @ if 0 d@ @ fremem then	( free name )
+	0 d@ @ if 0 d@ @ >d fremem then	( free name )
 	fremem ;
 
 \ Changes the name of the entity.
@@ -395,6 +476,14 @@ extern asmstrcmp
 : objDirParent ( a -- a' )
 	d> @ >d ;
 
+
+\ Assigns the object a new parent.  Objects can belong to only 
+\ one parent.
+
+: objDirSetParent ( p a -- )
+	d> d> swap ! ;
+
+
 \ Answers the first ObjEnt assigned to the directory.
 
 : objDirFirst ( a -- a' )
@@ -434,17 +523,25 @@ extern asmstrcmp
 
 \ Walks the object hierarchy by name, and if the named resource is
 \ found, return it and a true flag.  Otherwise, return a false flag.
+\
+\ Note that this procedure is recursive; it uses memory in proportion
+\ to the depth of the sought resource.  If the object tree is
+\ malformed so that a cycle exists, this procedure will overflow your
+\ stack and crash the system.
 
 : objDirWalk ( caddr u a -- a' -1 | ? 0 )
 	1 d@ 0=if	( null name? )
 		0 d@ 2 d!  d# -1 1 d!  d>  exit
 	then
-	objDirFirst begin 0 d@ while
-		2 d@ >d 2 d@ >d 2 d@ >d objEntIsNamed d> if
-			objEntObject d> 1 d!  d# -1 0 d! exit
+	objDirFirst  2 d@ >d  2 d@ >d  strSplitSlash ( caddr u e sa su pa pu )
+	begin 4 d@ while
+		1 d@ >d 1 d@ >d 6 d@ >d objEntIsNamed d> if
+			3 d@ 6 d!  2 d@ 5 d!
+			d> d> d> d>
+			objEntObject objDirWalk exit
 		then
-		objEntNext
-	repeat d# 0 1 d! d> ;
+		4 d@ >d objEntNext d> 4 d!
+	repeat d# 0 5 d! d> d> d> d> d> ;
 
 : objDirTCreate
 	objDirNew d> 0=if S"   create: failed" >d >d type cr bye then
@@ -471,34 +568,83 @@ extern asmstrcmp
 	1 d@ >d objDirRemHead d>
 	objEntDispose objDirDispose ;
 
-\ BSPL cannot record an empty string with S" ", so this procedure
-\ pushes a zero-length string onto the stack manually.
-: _emptystr
-	d# 0 >d d# 0 >d ;
-
-: objDirTWalk
+: objDirTWalk1
 	objDirNew d> 0=if S"   walk: dir" >d >d type cr bye then
+
+	objDirNew d> 0=if S"   walk: subdir" >d >d type cr bye then
+	1 d@ >d 1 d@ >d objDirSetParent
 
 	objEntNew d> 0=if S"   walk: ent" >d >d type cr bye then
 	S" woo" >d >d 2 d@ >d objEntSetName d> 0=if S"   walk: ent name" >d >d type cr bye then
-	h# 1111 >d 1 d@ >d objEntSetObject
-	0 d@ >d 2 d@ >d objDirAddHead
+	1 d@ >d 1 d@ >d objEntSetObject
+	0 d@ >d 3 d@ >d objDirAddHead
 
-	_emptystr 3 d@ >d objDirWalk
+	_emptystr 4 d@ >d objDirWalk
 		d> 0=if S" walk: can't find self" >d >d type cr bye then
-		d> 1 d@ xor if S"   walk: self expected" >d >d type cr bye then
-	S" woo" >d >d 3 d@ >d objDirWalk
+		d> 2 d@ xor if S"   walk: self expected" >d >d type cr bye then
+	S" woo" >d >d 4 d@ >d objDirWalk
 		d> 0=if S" walk: can't find woo" >d >d type cr bye then
-		d> h# 1111 xor if S"   walk: woo expected" >d >d type cr bye then
-	S" bar" >d >d 3 d@ >d objDirWalk
+		d> 1 d@ xor if S"   walk: woo expected" >d >d type cr bye then
+	S" bar" >d >d 4 d@ >d objDirWalk
 		d> if S" walk: missing file found?" >d >d type cr bye then
 		d>
 
-	objEntDispose objDirDispose ;
+	objEntDispose objDirDispose objDirDispose ;
 	
+: objDirTWalk2
+	\ Construct the following object tree:
+	\
+	\ root
+	\   sd1
+	\   sd2
+	\      sd3
+	\         sd4
+
+	objDirNew d> 0=if S"   walk2: root" >d >d type cr bye then
+	objDirNew d> 0=if S"   walk2: subdir1" >d >d type cr bye then
+	objDirNew d> 0=if S"   walk2: subdir2" >d >d type cr bye then
+	objDirNew d> 0=if S"   walk2: subdir3" >d >d type cr bye then
+	objDirNew d> 0=if S"   walk2: subdir4" >d >d type cr bye then
+
+	( root sd1 sd2 sd3 sd4 )
+
+	4 d@ >d 4 d@ >d objDirSetParent
+	4 d@ >d 3 d@ >d objDirSetParent
+	2 d@ >d 2 d@ >d objDirSetParent
+	1 d@ >d 1 d@ >d objDirSetParent
+
+	objEntNew d> 0=if S"   walk2: e1" >d >d type cr bye then
+	objEntNew d> 0=if S"   walk2: e2" >d >d type cr bye then
+	objEntNew d> 0=if S"   walk2: e3" >d >d type cr bye then
+	objEntNew d> 0=if S"   walk2: e4" >d >d type cr bye then
+
+	( root sd1 sd2 sd3 sd4 e1 e2 e3 e4 )
+	
+	S" sd1" >d >d 5 d@ >d objEntSetName d> 0=if S"   walk2: name sd1" >d >d type cr bye then
+	S" sd2" >d >d 4 d@ >d objEntSetName d> 0=if S"   walk2: name sd2" >d >d type cr bye then
+	S" sd3" >d >d 3 d@ >d objEntSetName d> 0=if S"   walk2: name sd3" >d >d type cr bye then
+	S" sd4" >d >d 2 d@ >d objEntSetName d> 0=if S"   walk2: name sd4" >d >d type cr bye then
+
+	7 d@ >d 4 d@ >d objEntSetObject
+	6 d@ >d 3 d@ >d objEntSetObject
+	5 d@ >d 2 d@ >d objEntSetObject
+	4 d@ >d 1 d@ >d objEntSetObject
+
+	3 d@ >d 9 d@ >d objDirAddHead
+	2 d@ >d 9 d@ >d objDirAddHead
+	1 d@ >d 7 d@ >d objDirAddHead
+	0 d@ >d 6 d@ >d objDirAddHead
+
+	S" sd2/sd3/sd4" >d >d 10 d@ >d objDirWalk
+		d> 0=if S"   walk2: can't find sd4" >d >d type cr bye then
+		d> 4 d@ xor if S"   walk2: sd4 expected" >d >d type cr bye then
+
+	objEntDispose objEntDispose objEntDispose objEntDispose
+	objDirDispose objDirDispose objDirDispose objDirDispose objDirDispose ;
+
 : objDirTest
 	S" objdir:" >d >d type cr
-	objDirTCreate objDirTParent objDirTEmpty objDirTFirst objDirTWalk
+	objDirTCreate objDirTParent objDirTEmpty objDirTFirst objDirTWalk1 objDirTWalk2
 	S" OK" >d >d type cr ;
 
 \ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
@@ -620,6 +766,6 @@ dword: re	( points just beyond last character )
 : mem0		h# 2000 >d  d# 16777216 d# 8192 - >d fmtmem ;
 		( Nexys2 has 16MB of on-board RAM )
 
-: selfTest	memtest objEntTest objDirTest ;
+: selfTest	memtest strTest objEntTest objDirTest ;
 : _		cr banner mem0 selfTest romshell bye ;
 

--- a/3/src/stsv1/stsv1.rom.asm
+++ b/3/src/stsv1/stsv1.rom.asm
@@ -9,6 +9,40 @@
 		include "bspl-abi/regs.i"
 		include	"bspl-abi/bspl-regs.i"
 
+; The following extra register definitions are required for the non-BSPL
+; code linked into the STS code image.
+
+rt		= ra	; Alias return stack for BSPL and non-BSPL code
+rp		= rsp
+
+a0		= x7	; Registers used by CompareNames.
+a1		= x8
+a2		= x9
+a3		= x10
+t1		= x11
+t2		= x12
+
 		include	"stsv1.asm"
+
+; The following string-compare software comes from a ROM-resident Forth
+; interpreter.  It's been unit-tested and shown to work in that project.
+
+		include "compareNames.asm"
+		include	"compareNamesUpToLength.asm"
+
+asmstrcmp:	addi	rsp, rsp, -8
+		sd	rt, 0(rsp)
+		ld	a0, 3*8(dsp)
+		ld	a2, 2*8(dsp)
+		ld	a1, 1*8(dsp)
+		ld	a3, 0(dsp)
+		jal	rt, compareNames
+		sd	a0, 3*8(dsp)
+		addi	dsp, dsp, 24
+		ld	rt, 0(rsp)
+		addi	rsp, rsp, 8
+		jalr	x0, 0(rt)
+
+; This must always be the last thing to appear in any BSPL program.
 
 		include	"bspl-abi/bspl-suffix.asm"


### PR DESCRIPTION
This isn't a complete filesystem yet, but it's the core component for one.

```
+-------------------+
|                   |
|   +-----------+   |
+-->| ObjDir    |   |
    +===========+   |
    | parent    |---+    +--------+
    | children  |----*-->| ObjEnt |
    | walk()    |    |   +========+
    | dispose() |    |   | name   |---------> "name of directory or file"
    +-----------+    |   | object |----+
                     +---| next   |    |    +-----------+
                         +--------+    +--->| Obj*      |
                                            +===========+
                                            | walk()    |
                                            | dispose() |
                                            | ...       |
                                            +-----------+
```
STS would maintain a global pointer to a root `ObjDir` instance.  This instance would refer to one or more children, whose names correspond to top-level filesystem handlers in TRIPOS (e.g., /sys would basically be an alias for the current boot volume, /sd0 would map to the first sd card unit, etc.).  Subdirectories might include low-level device drivers, like /dev/sd/0 for raw access to the SD card interface, for instance.  Also, /proc for process statistics, etc.  You get the idea.

`ObjEnt` structures are not objects; they're just (next, name, object) associations maintained in a singly linked list.  In this respect, the `ObjEnt` structure is an implementation detail exposed due to inadequate abstraction on the part of `Obj` structures (for now; expect this to get better in the future).

`ObjDir` is an instance of `Obj`, an abstract class of filesystem objects that cannot be directly instantiated on its own.  It's not in this commit, but I'm planning on a `RomFile` implementation which is also a kind of `Obj`, but which provides actual file semantics (as distinct from directory semantics).

The `walk` method (`objWalk` in the code) is responsible for processing one or more name components and walking its own, localized namespace.  If a resource is found, the remainder of the name is passed thereto, recursively, to complete the walk within its own context.  Note how `objDirWalk` invokes `objWalk` recursively once an `ObjEnt` with a matching name component is found.

Directories MAY return themselves if walking "", but aren't required to.  They MUST attempt to resolve a component if the path is non-empty.  Files have opposite semantics.  They MUST answer themselves if walking "", but MUST yield an error if an attempt is made to resolve beyond a file.

Other kinds of objects have their own unique semantics as well.  For example, a reparse- or symbolic-link object would be responsible for manipulating the passed filename and commencing the walk all over again from scratch.  (For this reason, I'd like to advocate against symbolic links until a proven need for them exists.)

Fixes #140 