### PR TITLE
Support scanning for RomTag structures.  Also, make shell use loadseg/unloadseg.

### DIFF
--- a/3/src/stsv1/default.rom.do
+++ b/3/src/stsv1/default.rom.do
@@ -1,4 +1,5 @@
 redo-ifchange ../../bin/a
 redo-ifchange $2.rom.asm $2.asm
+redo-ifchange romtag.asm
 
 a from $2.rom.asm to $3 quiet

--- a/3/src/stsv1/romtag.asm
+++ b/3/src/stsv1/romtag.asm
@@ -1,32 +1,3 @@
-; romtagtest drives the test cases for RomTag support.
-; This procedure will never return if a test fails.
-
-romtagmsg:	byte	"romtag:"
-romtaglen	= *-romtagmsg
-
-		align	4
-romtagtest:	auipc	gp, 0
-		addi	rsp, rsp, -8
-		sd	ra, 0(rsp)
-
-		addi	dsp, dsp, -16
-		addi	x16, gp, romtagmsg-romtagtest
-		sd	x16, 8(dsp)
-		addi	x16, x0, romtaglen
-		sd	x16, 0(dsp)
-		jal	ra, type
-		jal	ra, cr
-
-		jal	ra, rt1		; happy path
-		jal	ra, rt2		; bad checksum
-		jal	ra, rt3		; matchword 1
-		jal	ra, rt4		; matchword 2
-		jal	ra, rt5		; dword alignment
-
-		ld	ra, 0(rsp)
-		addi	rsp, rsp, 8
-		jalr	x0, 0(ra)
-
 ; A valid, if bogus, RomTag
 
 rt1fmsg:	byte	"   rt1"
@@ -204,6 +175,12 @@ rt5fail:	auipc	gp, 0
 		jal	ra, type
 		jal	ra, cr
 		jal	x0, bye
+
+; The following RomTag exists purely to satisfy the rt6 test in stsv1.bs.
+
+		align	8
+		word	$c0de0000, $0000da7a, 0, $FFFFFFFF-($c0de0000+$da7a+8)
+		word	1, 1, 1, 1, 1, 1, 1, 1
 
 ;
 ; Answers true if the specified RomTag is valid.

--- a/3/src/stsv1/romtag.asm
+++ b/3/src/stsv1/romtag.asm
@@ -1,0 +1,222 @@
+; romtagtest drives the test cases for RomTag support.
+; This procedure will never return if a test fails.
+
+romtagmsg:	byte	"romtag:"
+romtaglen	= *-romtagmsg
+
+		align	4
+romtagtest:	auipc	gp, 0
+		addi	rsp, rsp, -8
+		sd	ra, 0(rsp)
+
+		addi	dsp, dsp, -16
+		addi	x16, gp, romtagmsg-romtagtest
+		sd	x16, 8(dsp)
+		addi	x16, x0, romtaglen
+		sd	x16, 0(dsp)
+		jal	ra, type
+		jal	ra, cr
+
+		jal	ra, rt1		; happy path
+		jal	ra, rt2		; bad checksum
+		jal	ra, rt3		; matchword 1
+		jal	ra, rt4		; matchword 2
+
+		ld	ra, 0(rsp)
+		addi	rsp, rsp, 8
+		jalr	x0, 0(ra)
+
+; A valid, if bogus, RomTag
+
+rt1fmsg:	byte	"   rt1"
+rt1flen		= *-rt1fmsg
+
+		align	8
+validrt:	word	$c0de0000, $0000da7a, 1, $FFFFFFFF-($c0de0000+$da7a+9)
+		word	1, 1, 1, 1
+		word	1, 1, 1, 1
+
+; Given an address to a valid RomTag, isromtag should yield true.
+
+		align	4
+rt1:		auipc	gp, 0
+		addi	rsp, rsp, -8
+		sd	ra, 0(rsp)
+		addi	dsp, dsp, -8		; addr of romtag
+		addi	x16, gp, validrt-rt1
+		sd	x16, 0(dsp)
+		jal	ra, isromtag		; check
+		ld	x16, 0(dsp)		; zero if failed
+		beq	x16, x0, rt1fail
+		addi	dsp, dsp, 8		; pass
+		ld	ra, 0(rsp)
+		addi	rsp, rsp, 8
+		jalr	x0, 0(ra)
+
+rt1fail:	auipc	gp, 4
+		addi	dsp, dsp, -8		; print failure msg
+		addi	x16, gp, rt1fmsg-rt1fail
+		sd	x16, 8(dsp)
+		addi	x16, x0, rt1flen
+		sd	x16, 0(dsp)
+		jal	ra, type
+		jal	ra, cr
+		jal	x0, bye
+
+; Given an address to a RomTag with a bad checksum, isromtag should
+; yield false.
+
+rt2fmsg:	byte	"   rt2"
+rt2flen		= *-rt2fmsg
+
+		align	8
+invalidrt:	word	$c0de0000, $0000da7a, 0, $FFFFFFFF-($c0de0000+$da7a+9)
+		word	1, 1, 1, 1
+		word	1, 1, 1, 1
+
+		align	4
+rt2:		auipc	gp, 0
+		addi	rsp, rsp, -8
+		sd	ra, 0(rsp)
+		addi	dsp, dsp, -8
+		addi	x16, gp, invalidrt-rt1
+		sd	x16, 0(dsp)
+		jal	ra, isromtag
+		ld	x16, 0(dsp)
+		bne	x16, x0, rt2fail
+		addi	dsp, dsp, 8
+		ld	ra, 0(rsp)
+		addi	rsp, rsp, 8
+		jalr	x0, 0(ra)
+rt2fail:	auipc	gp, 0
+		addi	dsp, dsp, -8
+		addi	x16, gp, rt2fmsg-rt2fail
+		sd	x16, 8(dsp)
+		addi	x16, x0, rt2flen
+		sd	x16, 0(dsp)
+		jal	ra, type
+		jal	ra, cr
+		jal	x0, bye
+
+; Given an address to a RomTag with a bad matchword, isromtag should
+; yield false.
+
+rt3fmsg:	byte	"   rt3"
+rt3flen		= *-rt3fmsg
+
+		align	8
+invalidrt2:	word	$c0de0001, $0000da7a, 0, $FFFFFFFF-($c0de0000+$da7a+9)
+		word	1, 1, 1, 1
+		word	1, 1, 1, 1
+
+		align	4
+rt3:		auipc	gp, 0
+		addi	rsp, rsp, -8
+		sd	ra, 0(rsp)
+		addi	dsp, dsp, -8
+		addi	x16, gp, invalidrt2-rt1
+		sd	x16, 0(dsp)
+		jal	ra, isromtag
+		ld	x16, 0(dsp)
+		bne	x16, x0, rt3fail
+		addi	dsp, dsp, 8
+		ld	ra, 0(rsp)
+		addi	rsp, rsp, 8
+		jalr	x0, 0(ra)
+rt3fail:	auipc	gp, 0
+		addi	dsp, dsp, -8
+		addi	x16, gp, rt3fmsg-rt3fail
+		sd	x16, 8(dsp)
+		addi	x16, x0, rt3flen
+		sd	x16, 0(dsp)
+		jal	ra, type
+		jal	ra, cr
+		jal	x0, bye
+
+; Given an address to a RomTag with a bad matchword, isromtag should
+; yield false.
+
+rt4fmsg:	byte	"   rt4"
+rt4flen		= *-rt4fmsg
+
+		align	8
+invalidrt3:	word	$c0de0000, $0001da7a, 0, $FFFFFFFF-($c0de0000+$da7a+9)
+		word	1, 1, 1, 1
+		word	1, 1, 1, 1
+
+		align	4
+rt4:		auipc	gp, 0
+		addi	rsp, rsp, -8
+		sd	ra, 0(rsp)
+		addi	dsp, dsp, -8
+		addi	x16, gp, invalidrt3-rt1
+		sd	x16, 0(dsp)
+		jal	ra, isromtag
+		ld	x16, 0(dsp)
+		bne	x16, x0, rt4fail
+		addi	dsp, dsp, 8
+		ld	ra, 0(rsp)
+		addi	rsp, rsp, 8
+		jalr	x0, 0(ra)
+rt4fail:	auipc	gp, 0
+		addi	dsp, dsp, -8
+		addi	x16, gp, rt4fmsg-rt4fail
+		sd	x16, 8(dsp)
+		addi	x16, x0, rt4flen
+		sd	x16, 0(dsp)
+		jal	ra, type
+		jal	ra, cr
+		jal	x0, bye
+
+;
+; Answers true if the specified RomTag is valid.
+;
+; isromtag ( a -- -1|0 )
+;
+
+		align	4
+isrtm1:		word	$c0de0000
+isrtm2:		word	$0000da7a
+isromtag:	auipc	gp, 0
+		ld	t0, 0(dsp)	; T0 -> RomTag
+
+		lw	t1, 0(t0)	; Check first matchword
+		lw	t2, isrtm1-isromtag(gp)
+		bne	t1, t2, isrtn
+
+		lw	t1, 4(t0)	; Check second matchword
+		lw	t2, isrtm2-isromtag(gp)
+		bne	t1, t2, isrtn
+
+		addi	t1, x0, 0	; T1 = checksum
+		lw	t2,  0(t0)	; Calculate checksum of 48-byte RomTag
+		add	t1, t1, t2
+		lw	t2,  4(t0)
+		add	t1, t1, t2
+		lw	t2,  8(t0)
+		add	t1, t1, t2
+		lw	t2, 12(t0)
+		add	t1, t1, t2
+		lw	t2, 16(t0)
+		add	t1, t1, t2
+		lw	t2, 20(t0)
+		add	t1, t1, t2
+		lw	t2, 24(t0)
+		add	t1, t1, t2
+		lw	t2, 28(t0)
+		add	t1, t1, t2
+		lw	t2, 32(t0)
+		add	t1, t1, t2
+		lw	t2, 36(t0)
+		add	t1, t1, t2
+		lw	t2, 40(t0)
+		add	t1, t1, t2
+		lw	t2, 44(t0)
+		add	t1, t1, t2
+		addi	t2, x0, -1	; Checksum must match -1
+		beq	t1, t2, isrty
+isrtn:		sd	x0, 0(dsp)	; No, return false.
+		jalr	x0, 0(ra)
+isrty:		sd	t2, 0(dsp)	; Yes, return true.
+		jalr	x0, 0(ra)
+

--- a/3/src/stsv1/stsv1.bs
+++ b/3/src/stsv1/stsv1.bs
@@ -941,21 +941,6 @@ dword: rootnode
 
 \ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
-\ Filesystem Dispatcher and API
-
-
-\ loadseg is used to bring a program image into memory.
-\ unloadseg frees that memory.
-\
-\ loadseg ( caddr u -- a 0 | ? err )
-\ unloadseg ( a -- )
-
-: loadseg	d> d> d# 0 >d d# 123 >d ;
-
-: unloadseg	d> ;
-
-\ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
-
 \ The ROM-resident shell.  Eventually, this will be placed into
 \ an executable that resides in the ROM filesystem.  From there,
 \ it will eventually find its way onto removable media (e.g.,

--- a/3/src/stsv1/stsv1.bs
+++ b/3/src/stsv1/stsv1.bs
@@ -223,6 +223,21 @@ dword: mplsiz	\ Memory Pool Size
 
 \ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
+\ Filesystem Dispatcher and API
+
+
+\ loadseg is used to bring a program image into memory.
+\ unloadseg frees that memory.
+\
+\ loadseg ( caddr u -- a 0 | ? err )
+\ unloadseg ( a -- )
+
+: loadseg	d> d> d# 0 >d d# 123 >d ;
+
+: unloadseg	d> ;
+
+\ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
 \ The ROM-resident shell.  Eventually, this will be placed into
 \ an executable that resides in the ROM filesystem.  From there,
 \ it will eventually find its way onto removable media (e.g.,
@@ -331,8 +346,13 @@ dword: re	( points just beyond last character )
 
 : romshell
   cr ident initsh
-  begin	prompt accept cmd
-	cr type unknown cr
+  begin	prompt accept cr cmd
+	1 d@ >d 1 d@ >d loadseg d> if
+		d> type unknown cr
+	else
+		unloadseg
+		d> d>
+	then
 	d> d>
   again ;
 

--- a/3/src/stsv1/stsv1.bs
+++ b/3/src/stsv1/stsv1.bs
@@ -939,6 +939,71 @@ dword: rootnode
 	fsTOpenDir fsTOpenFile fsTLoadSeg
 	S" ok" >d >d type cr ;
 
+\ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+\
+\ RomTag structures are intended to stand out when sought.
+\ Embedded in code, they serve to point out to some other program
+\ some important detail about the block of memory (usually code)
+\ in which they sit.
+\ 
+\ +0	Match word 1.  This MUST be $C0DE0000.
+\ +4	Match word 2.  This MUST be $0000DA7A.
+\ +8	How many bytes to skip before finding the next RomTag.
+\ +12	Checksum.
+\ +16	128-bit component object interface ID.
+\ +32	Offset to component object.
+\ +40	Reserved; must be set to zero.
+\ +44	Reserved; must be set to zero.
+\ 
+\ A valid RomTag satisfies the following criteria:
+\ 
+\ 1.  All fields, when viewed as 32-bit words, must add up to $FFFFFFFF.
+\ 2.  The RomTag must be aligned on an 8-byte boundary.
+\ 3.  The offset to the component object is relative to the RomTag itself.
+\
+\ See romtag.asm for documentation on isromtag.
+extern isromtag
+
+\ Given a region of memory to scan, starting with start and ending with end,
+\ try to find a RomTag for an object with the provided interface (iidLo and
+\ iidHi).  If one is found, return its address and a success flag, such that,
+\ with minimum stack manipulation, continued application in a loop will find
+\ succeeding RomTags.  If no RomTag exists, pop everything off the stack and
+\ return a failure code.
+
+: findtag ( iidLo iidHi end start -- iidLo iidHi end addr -1 | 0 )
+	begin
+		0 d@ 1 d@ - +if  d> d> d> d> d# 0 >d exit  then
+		0 d@ >d isromtag d> if
+			0 d@ d# 16 + @ 2 d@ xor 0=if
+				0 d@ d# 24 + @ 3 d@ xor 0=if
+					d# -1 >d exit
+				then
+			then
+		then
+		0 d@ d# 8 + 0 d!
+	again ;
+
+extern rt1
+extern rt2
+extern rt3
+extern rt4
+extern rt5
+
+: rt6	h# 100000001 >d h# 100000001 >d d# -1 >d d# -1048576 >d findtag
+	d> d# -1 xor if S"   rt6: 1st" >d >d type cr bye then
+	d> d# 8 + >d findtag
+	d> d# -1 xor if S"   rt6: 2nd" >d >d type cr bye then
+	d> d> d> d> ;
+
+: rt7	h# ABCD >d h# DEF0 >d d# -1 >d d# -1048576 >d findtag
+	d> if S"   rt7" >d >d type cr bye then ;
+
+: romtagtest
+	S" romtag:" >d >d type cr
+	rt1 rt2 rt3 rt4 rt5 rt6 rt7
+	S" ok" >d >d type cr ;
+
 \ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
 \ The ROM-resident shell.  Eventually, this will be placed into
@@ -1073,7 +1138,6 @@ jump-entries: callTestProc banner ;
 : callTestProc	S" call:" >d >d type cr S" ok" >d >d type cr ;
 : callTest	ctvt call  ctvt d> d# 4 + >d call ;
 
-extern romtagtest
 
 : selfTest	memtest callTest strTest objEntTest objDirTest fsTest
 		romtagtest ;

--- a/3/src/stsv1/stsv1.bs
+++ b/3/src/stsv1/stsv1.bs
@@ -1059,8 +1059,6 @@ dword: re	( points just beyond last character )
 	d> d>
   again ;
 
-\ \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
-
 \ Luke-warm boot.  After BSPL's start-up code completes, it jumps to _
 \ (yes, that's a single underscore).  BSPL's runtime does not expect _ to
 \ return.
@@ -1075,6 +1073,10 @@ jump-entries: callTestProc banner ;
 : callTestProc	S" call:" >d >d type cr S" ok" >d >d type cr ;
 : callTest	ctvt call  ctvt d> d# 4 + >d call ;
 
-: selfTest	memtest callTest strTest objEntTest objDirTest fsTest ;
+extern romtagtest
+
+: selfTest	memtest callTest strTest objEntTest objDirTest fsTest
+		romtagtest ;
+
 : _		cr banner mem0 selfTest romshell bye ;
 

--- a/3/src/stsv1/stsv1.bs
+++ b/3/src/stsv1/stsv1.bs
@@ -308,24 +308,30 @@ dword: re	( points just beyond last character )
 
 : unknown	S" : unknown command" >d >d type ;
 
+\ Isolate the command in a command-line.  The original command string is not
+\ altered in any way.
+\ 
+\ cmd ( caddr u -- caddr u caddr' u' )
+
 : dropchar	d> d> d# 1 + >d d# 1 - >d ;
 
-: skipws
+: skipws ( caddr u -- caddr' u' )
   begin	0 d@ 0=if exit then
 	1 d@ c@ d# 33 - +if exit then
 	dropchar
   again ;
 
-: skipnws
+: skipnws ( caddr u -- caddr' u' )
   begin	0 d@ 0=if exit then
 	1 d@ c@ d# 33 - -if exit then
 	dropchar
   again ;
 
+: cmd		skipws 1 d@ >r skipnws 1 d@ 0 r@ - r> >d >d ;
+
 : romshell
   cr ident initsh
-  begin	prompt accept
-	skipws 1 d@ >r skipnws 1 d@ 0 r@ - r> >d >d
+  begin	prompt accept cmd
 	cr type unknown cr
 	d> d>
   again ;

--- a/3/src/stsv1/stsv1.rom.asm
+++ b/3/src/stsv1/stsv1.rom.asm
@@ -22,6 +22,7 @@ a3		= x10
 t1		= x11
 t2		= x12
 
+		include	"romtag.asm"
 		include	"stsv1.asm"
 
 ; The following string-compare software comes from a ROM-resident Forth


### PR DESCRIPTION
Fixes #150 