### PR TITLE
Enable "native" keyboard input.

### DIFF
--- a/3/src/bios/bios.asm
+++ b/3/src/bios/bios.asm
@@ -8,6 +8,7 @@
 		include	"bios.inc.asm"
 		include "bios.data.asm"
 		include "bios.mgia.asm"
+		include	"bios.kia2.asm"
 		include	"bios.jump.asm"
 		include	"bios.chr.asm"
 		include "math.asm"
@@ -64,6 +65,30 @@ bc100:		add	a1, s0, x0
 		byte	"Kestrel-3 BIOS V1.15.51"
 		byte	13, 10, 10, 0
 		align	4
+
+	addi a0, x0, $77
+	slli a0, a0, 8
+	ori a0, a0, $77
+	addi a1, x0, $FF
+	slli a1, a1, 16
+	sh a0, 1024(a1)
+
+_bc801:	addi a0, x0, 1
+	jalr ra, BIOS_CANINP(s7)
+	beq a0, x0, _bc801
+
+	addi a0, x0, 1
+	jalr ra, BIOS_CHRINP(s7)
+	addi a1, x0, $FF
+	slli a1, a1, 16
+	sh a0, 1104(a1)
+	srli a1, a0, 8
+	andi a1, a1, $80
+	bne a1, x0, _bc801
+	addi a1, a0, 0
+	addi a0, x0, 0
+	jalr ra, BIOS_CHROUT(s7)
+	jal x0, _bc801
 
 _bc900:		addi	a0, x0, 255
 		slli	a0, a0, 16

--- a/3/src/bios/bios.asm
+++ b/3/src/bios/bios.asm
@@ -124,6 +124,7 @@ _bi100:		auipc	gp, 0
 		sd	a0, bd_jumptab(x0)
 
 		jal	ra, mgia_init
+		jal	ra, kia2_init
 
 		ld	ra, 0(sp)
 		addi	sp, sp, 8

--- a/3/src/bios/bios.chr.asm
+++ b/3/src/bios/bios.chr.asm
@@ -9,7 +9,7 @@
 ; functions, along with some handy utilities suitable for these devices.
 
 
-MAX_CHRDEV	= 1
+MAX_CHRDEV	= 2
 
 chrdev_canout	= 0
 chrdev_chrout	= 4
@@ -122,6 +122,11 @@ _bios_chrtab:	jalr	a3, 0(a2)
 		jal	x0, bios_false
 		jal	x0, bios_false
 
+		jal	x0, bios_false		; Device 1: Raw Keyboard Input
+		jal	x0, bios_false
+		jal	x0, kia2_caninp
+		jal	x0, kia2_chrinp
+
 
 ;
 ; 
@@ -196,7 +201,7 @@ _so210:		lb	a2, 0(ra)
 		addi	ra, ra, 1
 		jal	x0, _so210
 
-_so200:		addi	ra, ra, 3
+_so200:		addi	ra, ra, 4
 		andi	ra, ra, -4
 		jal	x0, bios_strout
 

--- a/3/src/bios/bios.kia2.asm
+++ b/3/src/bios/bios.kia2.asm
@@ -1,0 +1,89 @@
+; Kestrel-3 BIOS (Basic Input/Output System)
+; Copyright (C) 2015 Samuel A. Falvo II
+; 
+; This Source Code Form is subject to the terms of the Mozilla Public
+; License, v. 2.0. If a copy of the MPL was not distributed with this
+; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;
+; KIA-II Driver
+
+; SYNOPSIS
+; kia2_init()
+;
+; FUNCTION
+;
+; Initialize the KIA-II core.
+
+kia2_init:	addi	a0, x0, $0200
+		slli	a0, a0, 48
+
+		; Attempt to clear the KIA queue.  The queue is only
+		; 16 elements deep, so we should trivially be able to
+		; do this.  However, to avoid deadlocking without any
+		; user-visible diagnostic, we bail after only 32 tries.
+
+		addi	a2, a2, 32
+_ki100:		addi	a2, a2, -1
+		beq	a2, x0, _ki110
+		lbu	a1, 0(a0)
+		andi	a1, a1, 1
+		beq	a1, x0, _ki100
+		jal	x0, 0(ra)
+
+		; If we're here, the KIA-II is either not present, or
+		; it is malfunctioning.
+
+_ki110:		addi	a0, x0, 0
+		jal	ra, bios_i_strout
+		byte	"KIA-II queue not empty after 32 tries.",13,10
+		byte	"Either the KIA-II core is bad, or the interface "
+		byte	"doesn't exist.",13,10,10
+		byte	"System halted.",13,10,0
+		align	4
+		jal	x0, *
+
+
+; SYNOPSIS
+;
+; yn = kia2_caninp(dev)
+; a0               a0
+;
+; INPUTS
+;    dev	Unused.
+;
+; FUNCTION
+; Return non-zero if at least one character awaits; zero otherwise.
+
+kia2_caninp:	addi	a0, x0, $0200
+		slli	a0, a0, 48
+		lbu	a0, 0(a0)
+		andi	a0, a0, 1
+		xori	a0, a0, 1
+		jalr	x0, 0(ra)
+
+; SYNOPSIS
+;
+; char = kia2_chrinp(dev)
+;  a0.h              a0
+;
+; INPUTS
+;    dev	Unused.
+;
+; FUNCTION
+; Returns the head of the KIA-II queue, then pops the queue.
+; Unlike most other character-oriented procedures, the results are 16-bits
+; wide.  Bit 15 is set if the key code is a key release event, and is clear
+; otherwise.  Bit 14 is set if bits 7-0 are not to be interpreted as ASCII,
+; but as a lower-level scancode.  This is used for non-ASCII-representable
+; codes, such as cursor keys or function keys.
+
+kia2_chrinp:	addi	a2, x0, $0200
+		slli	a2, a2, 48
+		lbu	a0, 0(a2)
+		andi	a0, a0, $C0
+		slli	a0, a0, 8
+		lbu	a1, 1(a2)
+		or	a0, a0, a1
+		sb	x0, 1(a2)
+		jalr	x0, 0(ra)
+

--- a/3/src/e/e.c
+++ b/3/src/e/e.c
@@ -153,6 +153,7 @@ int run(int argc, char *argv[]) {
 	char version[32];
 	int rc = 1;
 	AddressSpace *cpuAS = NULL;
+	SDL_Keycode k;
 
 	SDL_Init(SDL_INIT_VIDEO);
 
@@ -188,6 +189,16 @@ int run(int argc, char *argv[]) {
 			switch(sdlEvent.type) {
 			case SDL_QUIT:
 				running = 0;
+				break;
+			case SDL_KEYDOWN:
+				k = sdlEvent.key.keysym.sym;
+				k |= (k & 0x40000000) >> 16;
+				ekia_post((UHWORD)k);
+				break;
+			case SDL_KEYUP:
+				k = sdlEvent.key.keysym.sym;
+				k |= (k & 0x40000000) >> 16;
+				ekia_post((UHWORD)k | 0x8000);
 				break;
 			}
 		}


### PR DESCRIPTION
Enables KIA-II support in the emulator.  For details on the original KIA, see [its datasheet](https://github.com/KestrelComputer/kestrel/tree/master/cores/KIA/doc).  KIA-II differs from the original KIA in only two ways (only one of which is implemented right now):

1.  The KIA's QE flag is tied to a CPU interrupt input.  I don't yet emulate interrupts at all, so this isn't implemented just yet.

2.  The upper two bits of KQSTAT contains key down/up data and ASCII/non-ASCII type flags, suitable for use with the SDL keyboard event stream.  **NOTE: actual hardware will use the original KIA, since we will be talking to a PS/2 keyboard, not an SDL event stream.**  I will still tie QE to IRQ though.

Fixes #199 
Fixes #197 